### PR TITLE
fix a bug with poetry

### DIFF
--- a/man_spider/lib/__init__.py
+++ b/man_spider/lib/__init__.py
@@ -1,4 +1,4 @@
-import parser
+from .parser import *
 from .util import *
 from .logger import *
 from .spider import *


### PR DESCRIPTION
The method used to import parser library was breaking poetry ( and I think classic python install ? ) 
