### PR TITLE
New Option for ManSpider: Exclude a list of files from the parsing by content 

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,18 +133,19 @@ For example, you could specify any or all of these:
 
 ## Usage:
 ~~~
-usage: manspider [-h] [-u USERNAME] [-p PASSWORD] [-d DOMAIN] [-m MAXDEPTH] [-H HASH] [-t THREADS] [-f REGEX [REGEX ...]] [-e EXT [EXT ...]] [--exclude-extensions EXT [EXT ...]]
-                 [-c REGEX [REGEX ...]] [--sharenames SHARE [SHARE ...]] [--exclude-sharenames [SHARE ...]] [--dirnames DIR [DIR ...]] [--exclude-dirnames DIR [DIR ...]] [-q] [-n]
-                 [-mfail INT] [-o] [-s SIZE] [-v]
+usage: manspider [-h] [-u USERNAME] [-p PASSWORD] [-d DOMAIN] [-l LOOT_DIR] [-m MAXDEPTH] [-H HASH] [-t THREADS] [-f REGEX [REGEX ...]]
+                 [-e EXT [EXT ...]] [--exclude-extensions EXT [EXT ...]] [--exclude-files EXCLUDEDFILES [EXCLUDEDFILES ...]]
+                 [-c REGEX [REGEX ...]] [--sharenames SHARE [SHARE ...]] [--exclude-sharenames [SHARE ...]] [--dirnames DIR [DIR ...]]
+                 [--exclude-dirnames DIR [DIR ...]] [-q] [-n] [-mfail INT] [-o] [-s SIZE] [-v]
                  targets [targets ...]
 
 Scan for juicy data on SMB shares. Matching files and logs are stored in $HOME/.manspider. All filters are case-insensitive.
 
 positional arguments:
-  targets               IPs, Hostnames, CIDR ranges, or files containing targets to spider (NOTE: local searching also supported, specify directory name or keyword "loot" to search
-                        downloaded files)
+  targets               IPs, Hostnames, CIDR ranges, or files containing targets to spider (NOTE: local searching also supported, specify
+                        directory name or keyword "loot" to search downloaded files)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -u USERNAME, --username USERNAME
                         username for authentication
@@ -152,6 +153,8 @@ optional arguments:
                         password for authentication
   -d DOMAIN, --domain DOMAIN
                         domain for authentication
+  -l LOOT_DIR, --loot-dir LOOT_DIR
+                        loot directory (default ~/.manspider/)
   -m MAXDEPTH, --maxdepth MAXDEPTH
                         maximum depth to spider (default: 10)
   -H HASH, --hash HASH  NTLM hash for authentication
@@ -163,6 +166,8 @@ optional arguments:
                         only show filenames with these extensions (space-separated, e.g. `docx xlsx` for only word & excel docs)
   --exclude-extensions EXT [EXT ...]
                         ignore files with these extensions
+  --exclude-files EXCLUDEDFILES [EXCLUDEDFILES ...]
+                        dont parse files with these names (space-separated, e.g. `office.exe junk.bin` to skip parsing for office.exe & junk.data)
   -c REGEX [REGEX ...], --content REGEX [REGEX ...]
                         search for file content using regex (multiple supported)
   --sharenames SHARE [SHARE ...]
@@ -181,4 +186,19 @@ optional arguments:
   -s SIZE, --max-filesize SIZE
                         don't retrieve files over this size, e.g. "500K" or ".5M" (default: 10M)
   -v, --verbose         show debugging messages
+
+
+    # EXAMPLES
+
+    Example 1: Search the network for filenames that may contain creds
+    $ manspider 192.168.0.0/24 -f passw user admin account network login logon cred -d evilcorp -u bob -p Passw0rd
+
+    Example 2: Search for XLSX files containing "password"
+    $ manspider share.evilcorp.local -c password -e xlsx -d evilcorp -u bob -p Passw0rd
+
+    Example 3: Search for interesting file extensions
+    $ manspider share.evilcorp.local -e bat com vbs ps1 psd1 psm1 pem key rsa pub reg txt cfg conf config -d evilcorp -u bob -p Passw0rd
+
+    Example 4: Search for finance-related files
+    $ manspider share.evilcorp.local --dirnames bank financ payable payment reconcil remit voucher vendor eft swift -f '[0-9]{5,}' -d evilcorp -u bob -p Passw0rd
 ~~~

--- a/man_spider/lib/spider.py
+++ b/man_spider/lib/spider.py
@@ -51,7 +51,8 @@ class MANSPIDER:
             log.info(f'Searching by file extension: {extensions_str}')
 
         self.init_filename_filters(options.filenames)
-        self.parser = FileParser(options.content, quiet=self.quiet)
+        #! excluded files will not be parsed (work with both: remote and local manspider mode)
+        self.parser = FileParser(options.content, self.exclude_files, quiet=self.quiet)
 
         self.failed_logons = 0
 
@@ -88,7 +89,7 @@ class MANSPIDER:
                         if process is None or not process.is_alive():
                             # start spiderling
                             self.spiderling_pool[i] = multiprocessing.Process(
-                                target=Spiderling, args=(target, self.exclude_files, self), daemon=False
+                                target=Spiderling, args=(target, self), daemon=False
                             )
                             self.spiderling_pool[i].start()
                             # success, break out of infinite loop

--- a/man_spider/lib/spider.py
+++ b/man_spider/lib/spider.py
@@ -41,6 +41,10 @@ class MANSPIDER:
         self.or_logic           = options.or_logic
 
         self.extension_blacklist= options.exclude_extensions
+        
+        #! List of files to exclude from parsing
+        self.exclude_files = options.exclude_files
+
         self.file_extensions    = options.extensions
         if self.file_extensions:
             extensions_str = '"' + '", "'.join(list(self.file_extensions)) + '"'
@@ -84,7 +88,7 @@ class MANSPIDER:
                         if process is None or not process.is_alive():
                             # start spiderling
                             self.spiderling_pool[i] = multiprocessing.Process(
-                                target=Spiderling, args=(target, self), daemon=False
+                                target=Spiderling, args=(target, self.exclude_files, self), daemon=False
                             )
                             self.spiderling_pool[i].start()
                             # success, break out of infinite loop

--- a/man_spider/lib/spiderling.py
+++ b/man_spider/lib/spiderling.py
@@ -53,15 +53,12 @@ class Spiderling:
         '.xz',
     ]
 
-    def __init__(self, target, files_toskip, parent):
+    def __init__(self, target, parent):
 
         try:
 
             self.parent = parent
             self.target = target
-
-            #! Files to skip from parsing (excluded files)
-            self.files_toskip = files_toskip
 
 
             # unless we're only searching local files, connect to target
@@ -118,11 +115,6 @@ class Spiderling:
         else:
             # remote files
             for file in self.files:
-
-                #! Skip parsing for excluded files
-                if str(file).split("\\")[-1] in  self.files_toskip:
-                    log.debug(f"{self.target}: Skipping {str(file)}: match filenames to skip filters")
-                    continue
 
                 # if content searching is enabled, parse the file
                 if self.parent.parser.content_filters:

--- a/man_spider/lib/spiderling.py
+++ b/man_spider/lib/spiderling.py
@@ -53,12 +53,16 @@ class Spiderling:
         '.xz',
     ]
 
-    def __init__(self, target, parent):
+    def __init__(self, target, files_toskip, parent):
 
         try:
 
             self.parent = parent
             self.target = target
+
+            #! Files to skip from parsing (excluded files)
+            self.files_toskip = files_toskip
+
 
             # unless we're only searching local files, connect to target
             if type(self.target) == pathlib.PosixPath:
@@ -115,6 +119,11 @@ class Spiderling:
             # remote files
             for file in self.files:
 
+                #! Skip parsing for excluded files
+                if str(file).split("\\")[-1] in  self.files_toskip:
+                    log.debug(f"{self.target}: Skipping {str(file)}: match filenames to skip filters")
+                    continue
+
                 # if content searching is enabled, parse the file
                 if self.parent.parser.content_filters:
                     try:
@@ -169,8 +178,7 @@ class Spiderling:
         For sole purpose of threading
         '''
 
-        try:
-
+        try:        
             if type(file) == RemoteFile:
                 matches = self.parent.parser.parse_file(str(file.tmp_filename), pretty_filename=str(file))
                 if matches and not self.parent.no_download:

--- a/man_spider/manspider.py
+++ b/man_spider/manspider.py
@@ -90,6 +90,8 @@ def main():
     parser.add_argument('-f', '--filenames', nargs='+', default=[],         help=f'filter filenames using regex (space-separated)', metavar='REGEX')
     parser.add_argument('-e', '--extensions',nargs='+', default=[],         help='only show filenames with these extensions (space-separated, e.g. `docx xlsx` for only word & excel docs)', metavar='EXT')
     parser.add_argument('--exclude-extensions',nargs='+', default=[],       help='ignore files with these extensions', metavar='EXT')
+    # Argparser option to enter a list of excluded files from parsing
+    parser.add_argument('--exclude-files',nargs='+', default=[],       help='dont parse files with these names (space-separated, e.g. `office.exe junk.bin` to skip parsing for office.exe & junk.data)', metavar='EXCLUDEDFILES')
     parser.add_argument('-c', '--content',   nargs='+', default=[],         help='search for file content using regex (multiple supported)', metavar='REGEX')
     parser.add_argument('--sharenames',      nargs='+', default=[],         help='only search shares with these names (multiple supported)', metavar='SHARE')
     parser.add_argument('--exclude-sharenames', nargs='*', default=['IPC$', 'C$', 'ADMIN$', 'PRINT$'],help='don\'t search shares with these names (multiple supported)', metavar='SHARE')


### PR DESCRIPTION
Hello!,

First, thank you for this amazing tool.

# A little bit of context: 
I am using Manspider as part of a tool I am developing to discover and report all sensitive data exposed in the internal network of the company I am working for. We have too many shares to monitor continuously for sensitive data. 

When I was testing Manspider (against a pre-prod environment), I found that Manspider enters a blocked state when parsing certain types of files, and sometimes these files don’t have a specific extension which means I can’t exclude them using the `--exclude-extensions` option. 

As I want to use Manspider as part of my monitoring tool and I want my tool to run automatically (as a cronjob), I don’t want it to be blocked when parsing a file (enter a blocking state). I decided to contribute to this project by adding an option to exclude a list of files from the parsing process.

# The new option:
`–exclude-files` can now be used to exclude a list of files from the parsing process. 
If Manspider enters a blocking state due to a file parsing issue, the user can exclude this specific file by specifying its name.

This option will work with both local and remote modes.

## Example: Remote mode

```bash
python3 -m man_spider.manspider 192.168.56.22 -u 'testuser'  -p 'test123' -d 'north.sevenkingdoms.local' -t 10 -s 5M -m 2 --sharenames 'all' --loot-dir remote_loot -v -c "((secret|password|credentials|.*passe)\s{0,1}[:=]\S*)|(-----BEGIN[A-Z ]* PRIVATE KEY -----)" -q  --exclude-files KIX32.EXE nmap NTUSER.DAT{016888bd-6c6f-11de-8d1d-001e0bcde3ec}.TM.blf setup.rnm SharpHound.exe VERRACF.UPLOAD.XMI
.....

[*] 192.168.56.22: Downloading all\dev\setup.rnm
[*] Skipping 192.168.56.22\all\dev\NTUSER.DAT{016888bd-6c6f-11de-8d1d-001e0bcde3ec}.TM.blf: one of the filenames to skip
[*] 192.168.56.22: Downloading all\dev\SharpHound.exe
[*] Skipping 192.168.56.22\all\dev\setup.rnm: one of the filenames to skip
[*] 192.168.56.22: Downloading all\dev\sqmapi.dll
[*] Skipping 192.168.56.22\all\dev\SharpHound.exe: one of the filenames to skip
[*] 192.168.56.22: Downloading all\dev\test.txt
[*] Skipping 192.168.56.22\all\dev\sqmapi.dll: one of the filenames to skip
...
```
![image](https://github.com/blacklanternsecurity/MANSPIDER/assets/76757267/715dacea-84a0-48a6-82d2-395a92a43cd1)

## Example: Local mode
```bash
python3 -m man_spider.manspider testingmanspider --loot-dir local_loot -v -c "((secret|password|credentials|.*passe)\s{0,1}[:=]\S*)|(-----BEGIN[A-Z ]* PRIVATE KEY -----)" -q  --exclude-files KIX32.EXE nmap NTUSER.DAT{016888bd-6c6f-11de-8d1d-001e0bcde3ec}.TM.blf setup.rnm SharpHound.exe sqmapi.dll  VERRACF.UPLOAD.XMI
...
[*] ProcessPool: 4 processes finished
[*] Found file: testingmanspider/NTUSER.DAT{016888bd-6c6f-11de-8d1d-001e0bcde3ec}.TM.blf
[*] Skipping testingmanspider/NTUSER.DAT{016888bd-6c6f-11de-8d1d-001e0bcde3ec}.TM.blf: one of the filenames to skip
[*] ProcessPool: 6 processes started
[*] KIX32.EXE
[*] ProcessPool: 5 processes finished
[*] Found file: testingmanspider/report.md
[*] Parsing file: testingmanspider/report.md
[*] ProcessPool: 7 processes started
[*] nmap
[*] ProcessPool: 6 processes finished
[*] Found file: testingmanspider/KIX32.EXE
[*] Skipping testingmanspider/KIX32.EXE: one of the filenames to skip
[*] ProcessPool: 8 processes started
...
```
![image](https://github.com/blacklanternsecurity/MANSPIDER/assets/76757267/62c7ce8e-baba-4deb-b5b8-b299172e60d1)








