### PR TITLE
Fix AES key authentication

### DIFF
--- a/man_spider/lib/smb.py
+++ b/man_spider/lib/smb.py
@@ -118,6 +118,7 @@ class SMBClient:
                 except Exception as e:
                     log.debug(f"{self.server}: Error getting DNS domain: {e}")
                     self.dns_domain = self.domain if self.domain else ""
+                self.domain = self.domain if self.domain else self.dns_domain
 
         except Exception as e:
             log.debug(f"{self.server}: Error getting hostname: {e}")

--- a/man_spider/lib/spider.py
+++ b/man_spider/lib/spider.py
@@ -23,7 +23,7 @@ class MANSPIDER:
         self.password = options.password
         self.domain = options.domain
         self.nthash = options.hash
-        self.use_kerberos = options.kerberos
+        self.use_kerberos = options.kerberos or bool(options.aes_key)
         self.aes_key = options.aes_key
         self.dc_ip = options.dc_ip
         self.max_failed_logons = options.max_failed_logons


### PR DESCRIPTION
Hi :)

I needed AES authentication in manspider today and run into the problem that the authentication failed. This happens due to two logic flaws:
- Kerberos is not selected when an AES key is supplied
- The domain discovered in `get_hostname`  is never used because `self.domain` is never populated

I have fixed both to get AES authentication working. Here a before&after of the authenticating with AES:
<img width="1583" height="483" alt="image" src="https://github.com/user-attachments/assets/283693f8-003c-4eb2-a873-4dd60a23a6aa" />

Note that I intentionally didn't query anything that would have been found by manspider to keep the output small.