### PR TITLE
Fix anonymous share enumeration + JSON Lines output (shares, files, content matches) + Py3.14 console fix

### DIFF
--- a/man_spider/lib/logger.py
+++ b/man_spider/lib/logger.py
@@ -1,3 +1,6 @@
+import os
+import sys
+import json
 import logging
 from copy import copy
 from sys import stdout
@@ -5,6 +8,54 @@ from pathlib import Path
 from datetime import datetime
 from multiprocessing import Queue
 from logging.handlers import QueueHandler, QueueListener
+
+
+### JSON LINES OUTPUT ###
+
+# JSONL destination, configured once via set_json_output() before forking so that
+# child/worker processes inherit it (we force the "fork" start method).
+_json_output_path = None  # file path, when writing JSONL to a file
+_json_to_stdout = False  # when True, JSONL goes to stdout and logs go to stderr
+
+
+def set_json_output(path):
+    """
+    Configure JSONL output. "path" is:
+      - None / ""   -> disabled
+      - "-"         -> write JSONL to stdout, and redirect human-readable logs to stderr
+      - <filename>  -> append JSONL to that file
+    """
+    global _json_output_path, _json_to_stdout
+    if not path:
+        _json_output_path = None
+        _json_to_stdout = False
+    elif path == "-":
+        _json_output_path = None
+        _json_to_stdout = True
+        # keep stdout clean for JSONL: send all log records to stderr instead
+        console.setStream(sys.stderr)
+    else:
+        _json_output_path = str(path)
+        _json_to_stdout = False
+
+
+def json_log(record):
+    """
+    Emit a single record as one JSON line. No-op when --json wasn't specified.
+    Safe across processes: a short write() to an O_APPEND file, or a single
+    os.write() to stdout, is atomic on POSIX.
+    """
+    if not (_json_output_path or _json_to_stdout):
+        return
+    try:
+        line = json.dumps(record, default=str) + "\n"
+        if _json_to_stdout:
+            os.write(1, line.encode("utf-8"))
+        else:
+            with open(_json_output_path, "a", encoding="utf-8") as f:
+                f.write(line)
+    except Exception:
+        pass
 
 
 ### PRETTY COLORS ###

--- a/man_spider/lib/parser/parser.py
+++ b/man_spider/lib/parser/parser.py
@@ -219,6 +219,14 @@ class FileParser:
 
         for _filter, match_count in matches.items():
             log.info(ColoredFormatter.green(f'{pretty_filename}: matched "{_filter.pattern}" {match_count:,} times'))
+            json_log(
+                {
+                    "type": "content_match",
+                    "file": str(pretty_filename),
+                    "pattern": _filter.pattern,
+                    "count": match_count,
+                }
+            )
             # run grep for pretty output
             if not self.quiet:
                 self.grep(binary_content, _filter.pattern)

--- a/man_spider/lib/parser/parser.py
+++ b/man_spider/lib/parser/parser.py
@@ -219,14 +219,6 @@ class FileParser:
 
         for _filter, match_count in matches.items():
             log.info(ColoredFormatter.green(f'{pretty_filename}: matched "{_filter.pattern}" {match_count:,} times'))
-            json_log(
-                {
-                    "type": "content_match",
-                    "file": str(pretty_filename),
-                    "pattern": _filter.pattern,
-                    "count": match_count,
-                }
-            )
             # run grep for pretty output
             if not self.quiet:
                 self.grep(binary_content, _filter.pattern)

--- a/man_spider/lib/parser/parser.py
+++ b/man_spider/lib/parser/parser.py
@@ -81,6 +81,10 @@ class FileParser:
         ".dylib",
     }
 
+    # limits for the matched strings captured for JSON output
+    max_match_samples = 20  # max distinct matched strings kept per pattern per file
+    match_sample_maxlen = 256  # max length of each captured matched string
+
     def __init__(self, filters, quiet=False):
         self.init_content_filters(filters)
         self.quiet = quiet
@@ -210,15 +214,24 @@ class FileParser:
         except Exception:
             pass
 
-        # count the matches
-        for _filter, match in self.match(text_content):
-            try:
-                matches[_filter] += 1
-            except KeyError:
-                matches[_filter] = 1
+        # count the matches and capture a sample of the actual matched strings
+        for _filter, span in self.match(text_content):
+            entry = matches.get(_filter)
+            if entry is None:
+                entry = {"count": 0, "samples": []}
+                matches[_filter] = entry
+            entry["count"] += 1
+            if len(entry["samples"]) < self.max_match_samples:
+                sample = text_content[span[0]:span[1]][: self.match_sample_maxlen]
+                if sample not in entry["samples"]:
+                    entry["samples"].append(sample)
 
-        for _filter, match_count in matches.items():
-            log.info(ColoredFormatter.green(f'{pretty_filename}: matched "{_filter.pattern}" {match_count:,} times'))
+        for _filter, match_data in matches.items():
+            log.info(
+                ColoredFormatter.green(
+                    f'{pretty_filename}: matched "{_filter.pattern}" {match_data["count"]:,} times'
+                )
+            )
             # run grep for pretty output
             if not self.quiet:
                 self.grep(binary_content, _filter.pattern)

--- a/man_spider/lib/parser/parser.py
+++ b/man_spider/lib/parser/parser.py
@@ -214,7 +214,8 @@ class FileParser:
         except Exception:
             pass
 
-        # count the matches and capture a sample of the actual matched strings
+        # count the matches and capture a sample of the actual matched strings,
+        # including where in the file each one was found (1-based line/column)
         for _filter, span in self.match(text_content):
             entry = matches.get(_filter)
             if entry is None:
@@ -222,8 +223,13 @@ class FileParser:
                 matches[_filter] = entry
             entry["count"] += 1
             if len(entry["samples"]) < self.max_match_samples:
-                sample = text_content[span[0]:span[1]][: self.match_sample_maxlen]
-                if sample not in entry["samples"]:
+                start, end = span
+                value = text_content[start:end][: self.match_sample_maxlen]
+                line = text_content.count("\n", 0, start) + 1
+                column = start - text_content.rfind("\n", 0, start)
+                end_column = column + (end - start)
+                sample = {"match": value, "line": line, "column": column, "end_column": end_column}
+                if not any(s["match"] == value and s["line"] == line and s["column"] == column for s in entry["samples"]):
                     entry["samples"].append(sample)
 
         for _filter, match_data in matches.items():

--- a/man_spider/lib/smb.py
+++ b/man_spider/lib/smb.py
@@ -199,15 +199,19 @@ class SMBClient:
                             if s in str(e):
                                 log.warning(f"{self.server}: {s}: {self.username}")
 
-                    log.debug(f"{self.server}: Trying guest session")
-                    self.username = "Guest"
+                    # Prefer a true null/anonymous session first: on Samba, the SRVSVC
+                    # share-enumeration RPC (listShares) is permitted for anonymous logons
+                    # but denied for the "Guest" account, so null must be tried before Guest
+                    # to match `smbclient -L -N` behaviour.
+                    log.debug(f"{self.server}: Trying null session")
+                    self.username = ""
                     self.password = ""
                     self.domain = ""
                     self.nthash = ""
-                    guest_success = self.login(refresh=True, first_try=False)
-                    if not guest_success:
-                        log.debug(f"{self.server}: Switching to null session")
-                        self.username = ""
+                    null_success = self.login(refresh=True, first_try=False)
+                    if not null_success:
+                        log.debug(f"{self.server}: Switching to guest session")
+                        self.username = "Guest"
                         self.login(refresh=True, first_try=False)
 
             return False

--- a/man_spider/lib/spiderling.py
+++ b/man_spider/lib/spiderling.py
@@ -10,6 +10,7 @@ from man_spider.lib.smb import *
 from man_spider.lib.file import *
 from man_spider.lib.util import *
 from man_spider.lib.errors import *
+from man_spider.lib.logger import json_log
 from man_spider.lib.processpool import *
 
 
@@ -129,6 +130,16 @@ class Spiderling:
                 # otherwise, just save it
                 elif not self.local:
                     log.info(f"{self.target}: {file.share}\\{file.name} ({bytes_to_human(file.size)})")
+                    json_log(
+                        {
+                            "type": "file",
+                            "target": str(self.target),
+                            "share": file.share,
+                            "path": file.name,
+                            "size": file.size,
+                            "downloaded": not self.parent.no_download,
+                        }
+                    )
                     if not self.parent.no_download:
                         self.save_file(file)
 

--- a/man_spider/lib/spiderling.py
+++ b/man_spider/lib/spiderling.py
@@ -135,7 +135,8 @@ class Spiderling:
                     json_log(
                         {
                             "type": "file",
-                            "target": str(self.target),
+                            "target": self.target.host,
+                            "port": self.target.port,
                             "share": file.share,
                             "path": file.name,
                             "size": file.size,
@@ -194,6 +195,18 @@ class Spiderling:
         try:
             if type(file) == RemoteFile:
                 matches = self.parent.parser.parse_file(str(file.tmp_filename), pretty_filename=str(file))
+                for _filter, match_count in matches.items():
+                    json_log(
+                        {
+                            "type": "content_match",
+                            "target": self.target.host,
+                            "port": self.target.port,
+                            "share": file.share,
+                            "path": file.name,
+                            "pattern": _filter.pattern,
+                            "count": match_count,
+                        }
+                    )
                 if matches and not self.parent.no_download:
                     self.save_file(file)
                 else:

--- a/man_spider/lib/spiderling.py
+++ b/man_spider/lib/spiderling.py
@@ -195,7 +195,7 @@ class Spiderling:
         try:
             if type(file) == RemoteFile:
                 matches = self.parent.parser.parse_file(str(file.tmp_filename), pretty_filename=str(file))
-                for _filter, match_count in matches.items():
+                for _filter, match_data in matches.items():
                     json_log(
                         {
                             "type": "content_match",
@@ -204,7 +204,8 @@ class Spiderling:
                             "share": file.share,
                             "path": file.name,
                             "pattern": _filter.pattern,
-                            "count": match_count,
+                            "count": match_data["count"],
+                            "matches": match_data["samples"],
                         }
                     )
                 if matches and not self.parent.no_download:

--- a/man_spider/lib/spiderling.py
+++ b/man_spider/lib/spiderling.py
@@ -60,6 +60,8 @@ class Spiderling:
         try:
             self.parent = parent
             self.target = target
+            # ensures enumerated shares are logged/emitted only once per target
+            self._shares_logged = False
 
             # unless we're only searching local files, connect to target
             if type(self.target) == pathlib.PosixPath:
@@ -221,8 +223,25 @@ class Spiderling:
         # Keep track of shares we've already yielded to avoid duplicates
         yielded_shares = set()
 
+        enumerated_shares = self.smb_client.shares
+
+        # always report the shares we found, even while spidering with filters
+        if not self._shares_logged:
+            self._shares_logged = True
+            if enumerated_shares:
+                log.info(f"{self.target}: {len(enumerated_shares)} shares: {', '.join(enumerated_shares)}")
+                for share in enumerated_shares:
+                    json_log(
+                        {
+                            "type": "share",
+                            "target": self.target.host,
+                            "port": self.target.port,
+                            "share": share,
+                        }
+                    )
+
         # First, yield enumerated shares that match filters
-        for share in self.smb_client.shares:
+        for share in enumerated_shares:
             if self.share_match(share):
                 yielded_shares.add(share.lower())
                 yield share

--- a/man_spider/manspider.py
+++ b/man_spider/manspider.py
@@ -29,9 +29,37 @@ def go(options):
             )
             sleep(2)
 
-        # exit if no filters were specified
+        # if no filters were specified, just enumerate and print shares for each
+        # remote target (like `smbclient -L`) instead of spidering
         if not (options.filenames or options.extensions or options.exclude_extensions or options.content):
-            log.error("Please specify at least one of --filenames, --content, --extensions, or --exclude-extensions")
+            remote_targets = [t for t in options.targets if not isinstance(t, pathlib.PosixPath)]
+            if not remote_targets:
+                log.error("Please specify at least one of --filenames, --content, --extensions, or --exclude-extensions")
+                return
+            log.info("No filters specified; listing shares only")
+            for target in remote_targets:
+                smb_client = SMBClient(
+                    target.host,
+                    options.username,
+                    options.password,
+                    options.domain,
+                    options.hash,
+                    options.kerberos,
+                    options.aes_key,
+                    options.dc_ip,
+                    port=target.port,
+                )
+                if smb_client.login() is None:
+                    log.warning(f"{target.host}: Could not connect")
+                    continue
+                shares = smb_client.shares
+                if shares:
+                    log.info(f"{target.host}: {len(shares)} shares:")
+                    for share in shares:
+                        log.info(f"  {share}")
+                        json_log({"type": "share", "target": target.host, "port": target.port, "share": share})
+                else:
+                    log.warning(f"{target.host}: No shares found (or enumeration denied)")
             return
 
         # exit if --maxdepth is invalid
@@ -79,6 +107,16 @@ def load_content_wordlist(filepath, options):
 
 
 def main():
+
+    # The logging setup (lib/logger.py) shares a multiprocessing Queue between the
+    # parent's QueueListener (console output) and the child worker's QueueHandler.
+    # Python 3.14 changed the default start method on Linux to "forkserver", which
+    # re-imports modules in the child and creates a *new*, unlistened queue -> no
+    # console output. Force "fork" so parent and child share the same queue.
+    try:
+        multiprocessing.set_start_method("fork", force=True)
+    except (ValueError, RuntimeError):
+        pass
 
     interrupted = False
 
@@ -226,6 +264,16 @@ def main():
         metavar="DATE",
         help="only show files modified before this date (format: YYYY-MM-DD)",
     )
+    parser.add_argument(
+        "--json",
+        dest="json",
+        nargs="?",
+        const="-",
+        default=None,
+        metavar="FILE",
+        help="write results (shares, matched/looted files) as JSON Lines; to FILE, "
+        "or to stdout if no FILE is given (in which case logs are sent to stderr)",
+    )
 
     syntax_error = False
     try:
@@ -240,6 +288,9 @@ def main():
 
         if options.verbose:
             log.setLevel("DEBUG")
+
+        # configure JSON Lines output (must happen before forking the worker)
+        set_json_output(options.json)
 
         if options.kerberos and "KRB5CCNAME" not in os.environ:
             log.error("KRB5CCNAME is not set in the environment")

--- a/man_spider/manspider.py
+++ b/man_spider/manspider.py
@@ -315,17 +315,20 @@ def main():
         else:
             options.modified_before = None
 
-        # make sure extension formats are valid
-        for i, extension in enumerate(options.extensions):
-            if extension and not extension.startswith("."):
-                extension = f".{extension}"
-            options.extensions[i] = extension.lower()
+        # normalize extensions: split each entry on whitespace so that a quoted
+        # `--extensions "ini cfg"` behaves the same as `--extensions ini cfg`,
+        # then ensure a leading dot and lowercase
+        def normalize_extensions(extensions):
+            normalized = []
+            for entry in extensions:
+                for extension in entry.split():
+                    if not extension.startswith("."):
+                        extension = f".{extension}"
+                    normalized.append(extension.lower())
+            return normalized
 
-        # make sure extension blacklist is valid
-        for i, extension in enumerate(options.exclude_extensions):
-            if not extension.startswith("."):
-                extension = f".{extension}"
-            options.exclude_extensions[i] = extension.lower()
+        options.extensions = normalize_extensions(options.extensions)
+        options.exclude_extensions = normalize_extensions(options.exclude_extensions)
 
         # lowercase share names
         options.sharenames = [s.lower() for s in options.sharenames]


### PR DESCRIPTION
## Summary

A set of related fixes and features discovered while running `manspider` against a Samba host where `smbclient -L //host -N` listed shares fine but manspider returned nothing.

### 1. `fix(smb)`: use anonymous null session before Guest for share enumeration
When no credentials are supplied, `login()` switched to the `Guest` account and only fell back to a true null session if Guest *failed*. On Samba with `map to guest = Bad User`, the Guest login *succeeds*, but the SRVSVC `NetrShareEnumAll` RPC (`listShares`) is denied with `STATUS_ACCESS_DENIED` — so share enumeration silently returned nothing even though `smbclient -L -N` works. Now a true anonymous null session is attempted first, matching `smbclient -N`.

Verified directly with impacket against the same host:
```
NULL session ("")  : OK   -> ['myshare', 'IPC$']
Guest ("Guest","") : FAIL -> STATUS_ACCESS_DENIED
```

### 2. `fix(logging)`: force the `fork` multiprocessing start method
Python 3.14 changed the default start method on Linux to `forkserver`, which re-imports modules in the worker process and creates a *new*, unlistened log queue — so **no console output appeared at all** (only the file log). Forcing `fork` restores the shared queue between the parent's `QueueListener` and the worker's `QueueHandler`. Guarded with try/except so it's a no-op on older Pythons and degrades safely where `fork` is unavailable.

### 3. `feat(cli)`: list shares when no filter is given
When none of `--filenames/--content/--extensions/--exclude-extensions` are specified, manspider now enumerates and prints the shares for each remote target (like `smbclient -L`) instead of erroring out.

### 4. `feat`: always report enumerated shares while spidering
Previously the share list was only shown in no-filter mode. The enumerated shares are now reported once per target at INFO level (and emitted to JSON) regardless of whether filters are active.

### 5. `feat(output)`: `--json [FILE]` JSON Lines output
Adds machine-readable output. `--json FILE` appends JSON Lines to a file; `--json` with no argument writes JSONL to **stdout** and redirects human-readable logs to **stderr** (so stdout stays clean for piping).

Three record types, each carrying a consistent `target` + `port`:

```jsonl
{"type": "share", "target": "localhost", "port": 445, "share": "myshare"}
{"type": "file", "target": "localhost", "port": 445, "share": "myshare", "path": "sample.cfg", "size": 10, "downloaded": false}
{"type": "content_match", "target": "localhost", "port": 445, "share": "myshare", "path": "creds.cfg", "pattern": "password=\\S+", "count": 1, "matches": [{"match": "password=Sup3rS3cret!", "line": 2, "column": 1, "end_column": 22}]}
```

`content_match` records include a `matches` array with the **actual matched substrings** and **where they were found** — each entry is `{"match": ..., "line": N, "column": N, "end_column": N}` (1-based). Samples are deduped and capped at 20 distinct matches per pattern per file (each truncated to 256 chars). The substrings and locations are recovered from the regex span against the already-extracted text, so no extra scanning is performed.

## Testing
All behaviours verified end-to-end against a local Samba container (`myshare`, anonymous read-write): null-session enumeration, console output on Python 3.14.4, no-filter share listing, share reporting while spidering, and `--json` in both stdout and file modes including captured match strings with line/column locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)